### PR TITLE
Add 'no-shadowed-elements' rule and bump up the package version

### DIFF
--- a/config/.template-lintrc.js
+++ b/config/.template-lintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'inline-link-to': true,
     'inline-styles': true,
     'invalid-interactive': true,
+    'no-shadowed-elements': true,
     'link-rel-noopener': false,
     'nested-interactive': true,
     'self-closing-void-elements': true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hbslint-airhelp",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "AirHelp Handlebars Lint shareable cli and config",
   "bin": {
     "hbslint": "./bin/hbslint.js"


### PR DESCRIPTION
Docs: https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-shadowed-elements.md

We need this rule to make sure we don't encounter [this bug](https://github.com/emberjs/ember.js/issues/16826) after upgrading Ember to version 3.4 (and above)