### PR TITLE
Enable attribute indenting lint error

### DIFF
--- a/config/.template-lintrc.js
+++ b/config/.template-lintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: 'recommended',
 
   rules: {
+    'attribute-indentation': true,
     'block-indentation': true,
     'deprecated-each-syntax': true,
     'deprecated-inline-view-helper': true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hbslint-airhelp",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "AirHelp Handlebars Lint shareable cli and config",
   "bin": {
     "hbslint": "./bin/hbslint.js"


### PR DESCRIPTION
This PR introduces enabling linting for attribute in hbs templates. This change is to speed-up code review process.