### PR TITLE
Revert "Enable attribute indenting lint error"

### DIFF
--- a/config/.template-lintrc.js
+++ b/config/.template-lintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: 'recommended',
 
   rules: {
-    'attribute-indentation': true,
     'block-indentation': true,
     'deprecated-each-syntax': true,
     'deprecated-inline-view-helper': true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hbslint-airhelp",
-  "version": "1.0.10",
+  "version": "1.0.9",
   "description": "AirHelp Handlebars Lint shareable cli and config",
   "bin": {
     "hbslint": "./bin/hbslint.js"


### PR DESCRIPTION
Reverts AirHelp/hbslint-airhelp#18

This rule brings too big overhead, it requires some rules that we consider "ugly"