### PR TITLE
Bump minimist to 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "ember-template-lint": "^0.8.23",
+    "minimist": "^1.2.3",
     "walk-sync": "^0.3.2",
     "yargs": "^13.3.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,6 +775,11 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
+minimist@^1.2.3:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"


### PR DESCRIPTION
Due to vulnerability https://snyk.io/vuln/SNYK-JS-MINIMIST-559764 bumping the package to v1.2.3 as suggested on NPM https://www.npmjs.com/package/minimist